### PR TITLE
Added wrapping dagger

### DIFF
--- a/com.google.dagger/NOTICE
+++ b/com.google.dagger/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+dagger
+* License: Apache 2.0 License
+* Project: https://github.com/google/dagger
+* Source:  https://github.com/google/dagger

--- a/com.google.dagger/osgi.bnd
+++ b/com.google.dagger/osgi.bnd
@@ -1,0 +1,11 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Apache 2.0 License
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE

--- a/com.google.dagger/pom.xml
+++ b/com.google.dagger/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>com.google.dagger</artifactId>
+  <version>2.20</version>
+
+  <name>Dagger</name>
+
+  <properties>
+    <origin.groupId>com.google.dagger</origin.groupId>
+    <origin.artifactId>dagger</origin.artifactId>
+  </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <module>com.google.api.gax</module>
     <module>com.google.auth.google-auth-library-credentials</module>
     <module>com.google.auth.google-auth-library-oauth2-http</module>
+    <module>com.google.dagger</module>
     <module>com.google.http-client.google-http-client-gson</module>
     <module>com.google.http-client.google-http-client-jackson2</module>
     <module>com.google.re2j.re2j</module>


### PR DESCRIPTION
The dagger library is wrapped for openhab.tp-hivemqclient. See: https://github.com/openhab/openhab-core/blob/c50766d7c37a19f634e88fbe47b03b90215ab398/features/karaf/openhab-tp/src/main/feature/feature.xml#L68

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>