### PR TITLE
Provide TinyB specific headers in bundle.

### DIFF
--- a/intel-iot-devkit.tinyb/osgi.bnd
+++ b/intel-iot-devkit.tinyb/osgi.bnd
@@ -14,3 +14,7 @@ Bundle-NativeCode: \
   *
 -includeresource: \
   NOTICE
+
+Specification-Title: TinyB
+Specification-Vendor: Intel Corp.
+Specification-Version: 0.5


### PR DESCRIPTION
This commit refers to issue #13 and might affect already existing issue in openhab2 addons (see openhab/openhab-addons#5680).