### PR TITLE
Upgrade Travis CI to use Ubuntu 20.04 and fix warnings/caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
-sudo: required
-dist: xenial
+os: linux
+dist: focal
 
 language: java
-
-jdk:
-  - openjdk8
-  - openjdk11
+jdk: openjdk11
 
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/.bnd/cache/
 
 before_install:
   - echo "MAVEN_OPTS='-Xms1g -Xmx2g'" > ~/.mavenrc
@@ -34,7 +30,7 @@ install:
             tee .build.log | # write output to log
             stdbuf -oL grep -aE '^\[INFO\] Building .+ \[.+\]$' | # filter progress
             sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
-            sed -e :a -e 's/^.\{1,6\}|/ &/;ta' & # right align progress with padding
+            sed -e :a -e 's/^.\{1,4\}|/ &/;ta' & # right align progress with padding
         local pid=$!
         prevent_timeout $pid &
         wait $pid


### PR DESCRIPTION
Upgrades the Travis CI build environment to Ubuntu 20.04 (Focal Fossa).

Also fixes the following Travis configuration validation warnings:

* deprecated key sudo (The key `sudo` has no effect anymore.)
* missing os, using the default linux

Removes $HOME/.bnd/cache which does not exist after builds.

Removes Java 8 from the build matrix since it is EOL and OH3 also requires Java 11.

Removes unnecessary padding from build progress.