### PR TITLE
JinJava version updated to 2.5.7

### DIFF
--- a/com.hubspot.jinjava.jinjava/pom.xml
+++ b/com.hubspot.jinjava.jinjava/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>com.hubspot.jinjava.jinjava</artifactId>
-  <version>2.5.0</version>
+  <version>2.5.7</version>
 
   <name>JinJava</name>
 


### PR DESCRIPTION
The outdated JinJava library is a blocker for [#10496](https://github.com/openhab/openhab-addons/issues/10496). 
I would like to have the both versions in repository for now.