### PR TITLE
Add the Java-ipv6 library

### DIFF
--- a/com.googlecode.java-ipv6.java-ipv6/NOTICE
+++ b/com.googlecode.java-ipv6.java-ipv6/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+java-ipv6
+* License: Apache License 2.0
+* Project: https://github.com/janvanbesien/java-ipv6
+* Source: https://github.com/janvanbesien/java-ipv6

--- a/com.googlecode.java-ipv6.java-ipv6/osgi.bnd
+++ b/com.googlecode.java-ipv6.java-ipv6/osgi.bnd
@@ -1,0 +1,12 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Apache 2.0 License
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE
+

--- a/com.googlecode.java-ipv6.java-ipv6/pom.xml
+++ b/com.googlecode.java-ipv6.java-ipv6/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>com.googlecode.java-ipv6.java-ipv6</artifactId>
+  <version>0.17</version>
+
+  <name>Java IPv6 Library</name>
+
+  <properties>
+    <origin.groupId>com.googlecode.java-ipv6</origin.groupId>
+    <origin.artifactId>java-ipv6</origin.artifactId>
+  </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <module>com.google.http-client.google-http-client-gson</module>
     <module>com.google.http-client.google-http-client-jackson2</module>
     <module>com.google.re2j.re2j</module>
+    <module>com.googlecode.java-ipv6.java-ipv6</module>
     <module>com.goterl.lazycode.lazysodium-java</module>
     <module>com.hubspot.jinjava.jinjava</module>
     <module>com.igormaznitsa.jbbp</module>


### PR DESCRIPTION
The library is required by JinJava 2.5.7.

Or maybe there is a way to embed this dependency to OSGiified version of JinJava? 
I don't think that ipv6 library will be used somewhere else.