### PR TITLE
Add si-units with proper manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <module>org.pcap4j.pcap4j-core</module>
     <module>org.pcap4j.pcap4j-packetfactory-static</module>
     <module>org.zeromq.curve25519-java</module>
+    <module>si.uom-si-units</module>
   </modules>
 
   <scm>

--- a/si.uom-si-units/NOTICE
+++ b/si.uom-si-units/NOTICE
@@ -1,0 +1,52 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+si-units
+* License: BSD-3-Clause
+* Project: https://unitsofmeasurement.github.io/
+* Source:  https://github.com/unitsofmeasurement/si-units
+
+== Third-party license(s)
+
+=== BSD-3-Clause
+
+Copyright (c) 2005-2017, Jean-Marie Dautelle, Werner Keil and others.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ 3. Neither the name of JSR-363, Units of Measurement nor the names of their contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/si.uom-si-units/osgi.bnd
+++ b/si.uom-si-units/osgi.bnd
@@ -1,0 +1,13 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: BSD-3-Clause
+Bundle-SymbolicName: si-units
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE
+

--- a/si.uom-si-units/pom.xml
+++ b/si.uom-si-units/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>si.uom.si-units</artifactId>
+  <version>2.0.1</version>
+
+  <name>SI Units</name>
+
+  <properties>
+    <origin.groupId>si.uom</origin.groupId>
+    <origin.artifactId>si-units</origin.artifactId>
+  </properties>
+
+</project>


### PR DESCRIPTION
This allows for upgrading our UoM dependencies in https://github.com/openhab/openhab-core/pull/2319.
There is no recent si-units release that exports `si.uom` which is fixed by this PR.

When there is a usable si-units release, all we have to do is update the GAV parameters in the openhab-core runtime BOM and Karaf feature.

See also:

* https://github.com/openhab/openhab-core/pull/1664
* https://github.com/openhab/openhab-core/pull/1672