### PR TITLE
Update Dagger to 2.27

### DIFF
--- a/com.google.dagger/pom.xml
+++ b/com.google.dagger/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>com.google.dagger</artifactId>
-  <version>2.20</version>
+  <version>2.27</version>
 
   <name>Dagger</name>
 


### PR DESCRIPTION
This is the version used by hivemq-mqtt-client 1.2.2.