### PR TITLE
Update si-units to 2.1

### DIFF
--- a/si.uom-si-units/pom.xml
+++ b/si.uom-si-units/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>si.uom.si-units</artifactId>
-  <version>2.0.1</version>
+  <version>2.1</version>
 
   <name>SI Units</name>
 


### PR DESCRIPTION
Unfortunately the new version still does not export packages. :-/

Required for https://github.com/openhab/openhab-core/pull/2573