### PR TITLE
Update Maven plugin dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <bnd.version>5.3.0</bnd.version>
+    <bnd.version>6.2.0</bnd.version>
     <origin.version>${project.version}</origin.version>
   </properties>
 
@@ -105,7 +105,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.3.0</version>
           <executions>
             <!-- unpack dependency -->
             <execution>
@@ -178,7 +178,7 @@ Bundle-SymbolicName: ${project.artifactId}]]></bnd>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
           <executions>
             <execution>
               <id>attach-sources</id>


### PR DESCRIPTION
Updates the Maven plugins used in the build to:

* bnd 6.2.0
* build-helper-maven-plugin 3.3.0
* maven-dependency-plugin 3.3.0