### PR TITLE
Add a bundle for org.eclipse.equinox.common

### DIFF
--- a/org.eclipse.equinox.common/NOTICE
+++ b/org.eclipse.equinox.common/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+gax
+* License: Google License
+* Project: https://github.com/googleapis/gax-java
+* Source:  https://github.com/googleapis/gax-java

--- a/org.eclipse.equinox.common/osgi.bnd
+++ b/org.eclipse.equinox.common/osgi.bnd
@@ -1,0 +1,22 @@
+Bundle-Description: ${project.name} without dependency on Equinox Runtime
+Bundle-Name: ${project.name}
+Bundle-License: Google License
+Bundle-Version: ${project.version}
+Bundle-SymbolicName: org.eclipse.equinox.common; singleton:=true
+Bundle-Version: 3.17.100.v20230202-1341
+Bundle-Localization: plugin
+Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.c
+ ore.resources,org.eclipse.pde.build",org.eclipse.core.internal.runtime;
+ common=split;mandatory:=common; x-friends:="org.eclipse.core.contenttyp
+ e,  org.eclipse.core.jobs,  org.eclipse.equinox.preferences,  org.eclip
+ se.equinox.registry,  org.eclipse.core.runtime,  org.eclipse.core.runti
+ me.compatibility,  org.eclipse.core.filesystem,  org.eclipse.equinox.se
+ curity",org.eclipse.core.runtime;common=split;version="3.7.0";mandatory
+ :=common,org.eclipse.core.text;version="3.13.0",org.eclipse.equinox.eve
+ nts;version="1.0.0"
+Import-Package:
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.equinox.common
+-includeresource: \
+  NOTICE

--- a/org.eclipse.equinox.common/pom.xml
+++ b/org.eclipse.equinox.common/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.eclipse.equinox.common</artifactId>
+  <version>3.17.100</version>
+
+  <name>Equinox Common</name>
+
+  <properties>
+    <origin.groupId>org.eclipse.platform</origin.groupId>
+    <origin.artifactId>org.eclipse.equinox.common</origin.artifactId>
+  </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <module>io.socket.socket.io-client</module>
     <module>javazoom.jlayer</module>
     <module>net.vrallev.ecc.ecc-25519-java</module>
+    <module>org.eclipse.equinox.common</module>
     <module>org.cups4j.cups4j</module>
     <module>org.json.json</module>
     <module>org.pcap4j.pcap4j-core</module>


### PR DESCRIPTION
XText 2.30 depends on this bundle and unfortunately the newer versions of it depend on equinox.core which provides the runtime of equinox. If we deploy that, we run into conflicts with out felix runtime.