### PR TITLE
Update directory-watcher to 0.18.0

### DIFF
--- a/io.methvin.directory-watcher/pom.xml
+++ b/io.methvin.directory-watcher/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>io.methvin.directory-watcher</artifactId>
-  <version>0.17.1</version>
+  <version>0.18.0</version>
 
   <name>Directory-Watcher</name>
 


### PR DESCRIPTION
Updates the directory-watcher from 0.17.1 to 0.18.0.

This version has some bug fixes/improvements, see:

https://github.com/gmethvin/directory-watcher/compare/v0.17.1...v0.18.0