### PR TITLE
Remove Bountysource badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![GitHub Actions Build Status](https://github.com/openhab/openhab-osgiify/actions/workflows/ci-build.yml/badge.svg?branch=main)](https://github.com/openhab/openhab-osgiify/actions/workflows/ci-build.yml)
 [![Jenkins Build Status](https://ci.openhab.org/job/openhab-osgiify/badge/icon)](https://ci.openhab.org/view/All/job/openhab-osgiify/)
 [![EPL-2.0](https://img.shields.io/badge/license-EPL%202-green.svg)](https://opensource.org/licenses/EPL-2.0)
-[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=138067900)](https://www.bountysource.com/teams/openhab/issues?tracker_ids=138067900)
 
 This repository contains OSGI-ified versions of dependencies of the openHAB project.
 


### PR DESCRIPTION
It seems that Bountysource has been shut down as the website isn't reachable anymore and they don't respond to support mails.