### PR TITLE
Oracle JDBC driver

### DIFF
--- a/com.oracle.database.jdbc.ojdbc11/NOTICE
+++ b/com.oracle.database.jdbc.ojdbc11/NOTICE
@@ -1,0 +1,108 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+ojdbc11
+oraclepki
+
+* License: Oracle FDHUT license
+
+== Third-party license(s)
+
+=== Oracle Free Distribution, Hosting, and Use
+
+Your use of this Program is governed by the Oracle Free Distribution, Hosting, and Use Terms and Conditions set forth below, unless you have received this Program (alone or as part of another Oracle product) under an Oracle license agreement (including but not limited to the Oracle Master Agreement), in which case your use of this Program is governed solely by such license agreement with Oracle.
+
+
+
+Oracle Free Distribution, Hosting, and Use Terms and Conditions
+
+Definitions
+
+"Oracle" refers to Oracle America, Inc. "You" and "Your" refers to (a) a company or organization (each an "Entity") accessing the Programs, if use of the Programs will be on behalf of such Entity; or (b) an individual accessing the Programs, if use of the Programs will not be on behalf of an Entity. "Program(s)" refers to Oracle software provided by Oracle pursuant to the following terms and any updates, error corrections, and/or Program Documentation provided by Oracle. "Program Documentation" refers to Program user manuals and Program installation manuals, if any. If available, Program Documentation may be delivered with the Programs and/or may be accessed from www.oracle.com/documentation. "Separate Terms" refers to separate license terms that are specified in the Program Documentation, readmes or notice files and that apply to Separately Licensed Technology. "Separately Licensed Technology" refers to Oracle or third party technology that is licensed under Separate Terms and not under the terms of this license.
+
+
+
+Separately Licensed Technology
+
+Oracle may provide certain notices to You in Program Documentation, readmes or notice files in connection with Oracle or third party technology provided as or with the Programs. If specified in the Program Documentation, readmes or notice files, such technology will be licensed to You under Separate Terms. Your rights to use Separately Licensed Technology under Separate Terms are not restricted in any way by the terms herein. For clarity, notwithstanding the existence of a notice, third party technology that is not Separately Licensed Technology shall be deemed part of the Programs licensed to You under the terms of this license.
+
+
+
+Source Code for Open Source Software
+
+For software that You receive from Oracle in binary form that is licensed under an open source license that gives You the right to receive the source code for that binary, You can obtain a copy of the applicable source code from https://oss.oracle.com/sources/ or http://www.oracle.com/goto/opensourcecode. If the source code for such software was not provided to You with the binary, You can also receive a copy of the source code on physical media by submitting a written request pursuant to the instructions in the "Written Offer for Source Code" section of the latter website.
+
+
+
+-------------------------------------------------------------------------------
+
+The following license terms apply to those Programs that are not provided to You under Separate Terms.
+
+License Rights and Restrictions
+
+Oracle grants to You, as a recipient of this Program, a nonexclusive, nontransferable, limited license to, subject to the conditions stated herein, use the unmodified Programs, including, without limitation, for the purposes of:
+
+â€¢ developing, testing, prototyping and demonstrating applications; 
+
+â€¢ running the unmodified Programs for training, personal use, your business operations, and the business operations of third parties;
+
+â€¢ making the unmodified Programs available for use by third parties in your hosted environment and in cloud services; 
+
+â€¢ redistributing unmodified Programs and Programs Documentation under the terms of this License; and
+
+â€¢ copying the unmodified Programs and Program Documentation to the extent reasonably necessary to exercise the license rights granted herein and for backup purposes.
+
+For the purposes of this license, compiling, interpreting or configuring an otherwise unmodified Program as necessary to run the Program shall not be considered modification.
+
+
+
+Your license is contingent on Your compliance with the following conditions:
+
+- You include a copy of this license with any distribution by You of the Programs;
+
+- You do not charge your customers, end users, distributees or other third parties any additional fees for the distribution or use of the Programs; however, for clarity, if you comply with the foregoing condition, distribution or use of the Program as part of your for-fee product or service that adds substantial additional value is permitted; 
+
+- You do not remove markings or notices of either Oracle's or a licensor's proprietary rights from the Programs or Program Documentation;
+
+- You comply with all U.S. and applicable export control and economic sanctions laws and regulations that govern Your use of the Programs (including technical data); and
+
+- You do not cause or permit reverse engineering, disassembly or decompilation of the Programs (except as allowed by law) by You nor allow an associated party to do so.
+
+Any source code that may be included in the distribution with the Programs may not be modified, unless such source code is under Separate Terms permitting modification.
+
+Ownership
+
+Oracle or its licensors retain all ownership and intellectual property rights to the Programs.
+
+
+
+Information Collection
+
+The Programs' installation and/or auto-update processes, if any, may transmit a limited amount of data to Oracle or its service provider about those processes to help Oracle understand and optimize them. Oracle does not associate the data with personally identifiable information. Refer to Oracle's Privacy Policy at www.oracle.com/privacy.
+
+
+
+Disclaimer of Warranties; Limitation of Liability
+
+THE PROGRAMS ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. ORACLE FURTHER DISCLAIMS ALL WARRANTIES, EXPRESS AND IMPLIED, INCLUDING WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NONINFRINGEMENT.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW WILL ORACLE BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+
+
+Version 1.0 
+
+Last updated:  28 June 2022

--- a/com.oracle.database.jdbc.ojdbc11/osgi.bnd
+++ b/com.oracle.database.jdbc.ojdbc11/osgi.bnd
@@ -21,6 +21,7 @@ Import-Package: \
 	org.graalvm.*;'resolution:'=optional,\
 	org.objectweb.*;'resolution:'=optional,\
 	sun.security.krb5.internal;'resolution:'=optional,\
+	com.sun.security.jgss;'resolution:'=optional,\
 	weblogic.transaction;'resolution:'=optional,\
 	*
 Export-Package: \

--- a/com.oracle.database.jdbc.ojdbc11/osgi.bnd
+++ b/com.oracle.database.jdbc.ojdbc11/osgi.bnd
@@ -1,0 +1,30 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Oracle Free Distribution, Hosting, and Use Terms and Conditions
+Bundle-Version: ${project.version}
+Import-Package: \
+	com.oracle.common.*;'resolution:'=optional,\
+	com.oracle.net.*;'resolution:'=optional,\
+	com.oracle.svm.*;'resolution:'=optional,\
+	jakarta.json.*;'resolution:'=optional,\
+	javax.json.*;'resolution:'=optional,\
+	javax.resource.*;'resolution:'=optional,\
+	javax.transaction.*;'resolution:'=optional,\
+	oracle.as.*;'resolution:'=optional,\
+	oracle.core.ojdl;'resolution:'=optional,\
+	oracle.dms.*;'resolution:'=optional,\
+	oracle.i18n.*;'resolution:'=optional,\
+	oracle.security.*;'resolution:'=optional,\
+	oracle.simplefan;'resolution:'=optional,\
+	oracle.ucp.*;'resolution:'=optional,\
+	oracle.xdb;'resolution:'=optional,\
+	org.graalvm.*;'resolution:'=optional,\
+	org.objectweb.*;'resolution:'=optional,\
+	sun.security.krb5.internal;'resolution:'=optional,\
+	weblogic.transaction;'resolution:'=optional,\
+	*
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE

--- a/com.oracle.database.jdbc.ojdbc11/pom.xml
+++ b/com.oracle.database.jdbc.ojdbc11/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>com.oracle.database.jdbc.ojdbc11</artifactId>
+  <version>23.5.0.2407</version>
+
+  <name>Oracle JDBC 4.3 driver</name>
+
+  <properties>
+    <origin.groupId>com.oracle.database.jdbc</origin.groupId>
+    <origin.artifactId>ojdbc11</origin.artifactId>
+    <origin.version>23.5.0.24.07</origin.version>
+  </properties>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <module>com.microsoft.azure.sdk.iot.iot-device-client</module>
     <module>com.microsoft.azure.sdk.iot.iot-service-client</module>
     <module>com.nimbusds.srp6a</module>
+    <module>com.oracle.database.jdbc.ojdbc11</module>
     <module>com.pi4j.pi4j-gpio-extension</module>
     <module>com.squareup.okhttp.okhttp</module>
     <module>com.squareup.okio.okio</module>


### PR DESCRIPTION
Wrapping of the Oracle JDBC driver, required to be able to extend the JDBC persistence addon with support for the Oracle Database.