### PR TITLE
Fix jinjava optional imports

### DIFF
--- a/com.hubspot.jinjava.jinjava/osgi.bnd
+++ b/com.hubspot.jinjava.jinjava/osgi.bnd
@@ -3,6 +3,8 @@ Bundle-Name: ${project.name}
 Bundle-License: Apache 2.0 License
 Bundle-Version: ${project.version}
 Import-Package: \
+  javax.annotation.*;resolution:=optional; \
+  com.googlecode.ipv6.*;resolution:=optional; \
   *
 Export-Package: \
   !NOTICE, \


### PR DESCRIPTION
Unfortunately there are some changes needed to properly use them as OSGi bundles. Follow-up to #48.