### PR TITLE
OSGi-ify all Graal dependencies

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17' ]
+        java: [ '21' ]
         maven: [ '3.9.9']
         os: [ 'ubuntu-24.04' ]
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '21' ]
-        maven: [ '3.9.9']
+        maven: [ '3.9.10']
         os: [ 'ubuntu-24.04' ]
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ This repository contains OSGI-ified versions of dependencies of the openHAB proj
 
 Individual bundles may have different licenses. 
 See the NOTICE file in each directory.
+
+> [!NOTE]
+> When using the GraalVM collection of bundles, it's important to know that internally it uses ServiceLoader in various locations, which is strictly speaking incompatible with OSGi bundles which each have their own ClassLoader.
+> Instead, the OSGi Service Loader Mediator is used to take services published with the Service Provider Interface and publish them as OSGi services so that other bundles can find them.
+> Subsequently, the Mediator is also used on the consuming end for the bundles that use ServiceLoader.load to re-write that code on-the-fly to query from the OSGi service registry instead.
+> This is managed via additional headers in the osgi.bnd files as appropriate.
+> The caveat to this process is that because these bundles aren't truly aware of OSGi's dynamic loading, they just assume that all services will be available when they start up, and can't be notified of (optional) bundles that start afterwards.
+> Due to this, any feature that makes use of GraalVM needs to adjust bundle start levels to ensure the approriate dependencies are available in the correct order:
+> - Any bundle that provides a language or resources needs to load at start level 78 (before truffle-api)
+> - Truffle API needs to load at start level 79 (before polyglot)
+> - The rest of the bundles can load at their default start level 80

--- a/org.graalvm.js.js-language/NOTICE
+++ b/org.graalvm.js.js-language/NOTICE
@@ -15,6 +15,6 @@ https://github.com/openhab/openhab-osgiify
 == Third-party Content
 
 polyglot
-* License: Universal Permissive License
+* License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graaljs

--- a/org.graalvm.js.js-language/NOTICE
+++ b/org.graalvm.js.js-language/NOTICE
@@ -14,7 +14,7 @@ https://github.com/openhab/openhab-osgiify
 
 == Third-party Content
 
-polyglot
+graaljs
 * License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graaljs

--- a/org.graalvm.js.js-language/NOTICE
+++ b/org.graalvm.js.js-language/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graaljs

--- a/org.graalvm.js.js-language/osgi.bnd
+++ b/org.graalvm.js.js-language/osgi.bnd
@@ -3,10 +3,7 @@ Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
-  com.sun.security.auth;resolution:="optional", \
-  com.sun.security.auth.module;resolution:="optional", \
   com.sun.management;resolution:="optional", \
-  org.apache.arrow.vector;resolution:="optional", \
   *
 Export-Package: \
   !NOTICE, \

--- a/org.graalvm.js.js-language/osgi.bnd
+++ b/org.graalvm.js.js-language/osgi.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
-Bundle-License: Unicode/ICU License
+Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
   com.sun.security.auth;resolution:="optional", \

--- a/org.graalvm.js.js-language/osgi.bnd
+++ b/org.graalvm.js.js-language/osgi.bnd
@@ -1,0 +1,17 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Unicode/ICU License
+Bundle-Version: ${project.version}
+Import-Package: \
+  com.sun.security.auth;resolution:="optional", \
+  com.sun.security.auth.module;resolution:="optional", \
+  com.sun.management;resolution:="optional", \
+  org.apache.arrow.vector;resolution:="optional", \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="com.oracle.truffle.api.provider.TruffleLanguageProvider"  
+-includeresource: \
+  NOTICE

--- a/org.graalvm.js.js-language/pom.xml
+++ b/org.graalvm.js.js-language/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.js.js-language</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: JS :: Language</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.js</origin.groupId>
+    <origin.artifactId>js-language</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.js.js-scriptengine/NOTICE
+++ b/org.graalvm.js.js-scriptengine/NOTICE
@@ -15,6 +15,6 @@ https://github.com/openhab/openhab-osgiify
 == Third-party Content
 
 polyglot
-* License: Universal Permissive License
+* License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graaljs

--- a/org.graalvm.js.js-scriptengine/NOTICE
+++ b/org.graalvm.js.js-scriptengine/NOTICE
@@ -14,7 +14,7 @@ https://github.com/openhab/openhab-osgiify
 
 == Third-party Content
 
-polyglot
+graaljs
 * License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graaljs

--- a/org.graalvm.js.js-scriptengine/NOTICE
+++ b/org.graalvm.js.js-scriptengine/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graaljs

--- a/org.graalvm.js.js-scriptengine/osgi.bnd
+++ b/org.graalvm.js.js-scriptengine/osgi.bnd
@@ -2,12 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  com.sun.security.auth;resolution:="optional", \
-  com.sun.security.auth.module;resolution:="optional", \
-  com.sun.management;resolution:="optional", \
-  org.apache.arrow.vector;resolution:="optional", \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.js.js-scriptengine/osgi.bnd
+++ b/org.graalvm.js.js-scriptengine/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.js.js-scriptengine/osgi.bnd
+++ b/org.graalvm.js.js-scriptengine/osgi.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
-Bundle-License: Unicode/ICU License
+Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
   com.sun.security.auth;resolution:="optional", \

--- a/org.graalvm.js.js-scriptengine/osgi.bnd
+++ b/org.graalvm.js.js-scriptengine/osgi.bnd
@@ -1,0 +1,17 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Unicode/ICU License
+Bundle-Version: ${project.version}
+Import-Package: \
+  com.sun.security.auth;resolution:="optional", \
+  com.sun.security.auth.module;resolution:="optional", \
+  com.sun.management;resolution:="optional", \
+  org.apache.arrow.vector;resolution:="optional", \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="com.oracle.truffle.api.provider.TruffleLanguageProvider"  
+-includeresource: \
+  NOTICE

--- a/org.graalvm.js.js-scriptengine/pom.xml
+++ b/org.graalvm.js.js-scriptengine/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.js.js-scriptengine</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: JS :: Script Engine</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.js</origin.groupId>
+    <origin.artifactId>js-scriptengine</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.llvm.llvm-api/NOTICE
+++ b/org.graalvm.llvm.llvm-api/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License, Version 1.0
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graal

--- a/org.graalvm.llvm.llvm-api/osgi.bnd
+++ b/org.graalvm.llvm.llvm-api/osgi.bnd
@@ -9,4 +9,3 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.llvm.llvm-api/osgi.bnd
+++ b/org.graalvm.llvm.llvm-api/osgi.bnd
@@ -1,0 +1,12 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Universal Permissive License, Version 1.0
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE
+

--- a/org.graalvm.llvm.llvm-api/osgi.bnd
+++ b/org.graalvm.llvm.llvm-api/osgi.bnd
@@ -2,8 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.llvm.llvm-api/osgi.bnd
+++ b/org.graalvm.llvm.llvm-api/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.llvm.llvm-api/pom.xml
+++ b/org.graalvm.llvm.llvm-api/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.llvm.llvm-api</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: LLVM :: API</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.llvm</origin.groupId>
+    <origin.artifactId>llvm-api</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.polyglot.polyglot/NOTICE
+++ b/org.graalvm.polyglot.polyglot/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License, Version 1.0
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graal

--- a/org.graalvm.polyglot.polyglot/osgi.bnd
+++ b/org.graalvm.polyglot.polyglot/osgi.bnd
@@ -1,0 +1,18 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Universal Permissive License, Version 1.0
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+Require-Capability: \
+  osgi.extender; \
+    filter:="(osgi.extender=osgi.serviceloader.processor)", \
+  osgi.serviceloader; \
+    filter:="(osgi.serviceloader=org.graalvm.polyglot.impl.AbstractPolyglotImpl)"; \
+    cardinality:=multiple
+-includeresource: \
+  NOTICE
+

--- a/org.graalvm.polyglot.polyglot/osgi.bnd
+++ b/org.graalvm.polyglot.polyglot/osgi.bnd
@@ -15,4 +15,3 @@ Require-Capability: \
     cardinality:=multiple
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.polyglot.polyglot/pom.xml
+++ b/org.graalvm.polyglot.polyglot/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.polyglot.polyglot</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Polyglot :: Polyglot</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.polyglot</origin.groupId>
+    <origin.artifactId>polyglot</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.python.python-embedding/NOTICE
+++ b/org.graalvm.python.python-embedding/NOTICE
@@ -14,7 +14,7 @@ https://github.com/openhab/openhab-osgiify
 
 == Third-party Content
 
-polyglot
-* License: Universal Permissive License
+graalpy
+* License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graalpython

--- a/org.graalvm.python.python-embedding/NOTICE
+++ b/org.graalvm.python.python-embedding/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graalpython

--- a/org.graalvm.python.python-embedding/osgi.bnd
+++ b/org.graalvm.python.python-embedding/osgi.bnd
@@ -1,0 +1,15 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Unicode/ICU License
+Bundle-Version: ${project.version}
+Import-Package: \
+  org.graalvm.*;resolution:="optional", \
+  *
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE
+

--- a/org.graalvm.python.python-embedding/osgi.bnd
+++ b/org.graalvm.python.python-embedding/osgi.bnd
@@ -2,11 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  org.graalvm.*;resolution:="optional", \
-  *
-Import-Package: \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.python.python-embedding/osgi.bnd
+++ b/org.graalvm.python.python-embedding/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.python.python-embedding/osgi.bnd
+++ b/org.graalvm.python.python-embedding/osgi.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
-Bundle-License: Unicode/ICU License
+Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
   org.graalvm.*;resolution:="optional", \
@@ -12,4 +12,3 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.python.python-embedding/pom.xml
+++ b/org.graalvm.python.python-embedding/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.python.python-embedding</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Python :: Embedding</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.python</origin.groupId>
+    <origin.artifactId>python-embedding</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.python.python-language/NOTICE
+++ b/org.graalvm.python.python-language/NOTICE
@@ -14,7 +14,7 @@ https://github.com/openhab/openhab-osgiify
 
 == Third-party Content
 
-polyglot
-* License: Universal Permissive License
+graalpy
+* License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graalpython

--- a/org.graalvm.python.python-language/NOTICE
+++ b/org.graalvm.python.python-language/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graalpython

--- a/org.graalvm.python.python-language/osgi.bnd
+++ b/org.graalvm.python.python-language/osgi.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
-Bundle-License: Unicode/ICU License
+Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
   com.sun.security.auth;resolution:="optional", \

--- a/org.graalvm.python.python-language/osgi.bnd
+++ b/org.graalvm.python.python-language/osgi.bnd
@@ -1,0 +1,17 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Unicode/ICU License
+Bundle-Version: ${project.version}
+Import-Package: \
+  com.sun.security.auth;resolution:="optional", \
+  com.sun.security.auth.module;resolution:="optional", \
+  com.sun.management;resolution:="optional", \
+  org.apache.arrow.vector;resolution:="optional", \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="com.oracle.truffle.api.provider.TruffleLanguageProvider"  
+-includeresource: \
+  NOTICE

--- a/org.graalvm.python.python-language/pom.xml
+++ b/org.graalvm.python.python-language/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.python.python-language</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Python :: Language</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.python</origin.groupId>
+    <origin.artifactId>python-language</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.python.python-resources/NOTICE
+++ b/org.graalvm.python.python-resources/NOTICE
@@ -14,7 +14,7 @@ https://github.com/openhab/openhab-osgiify
 
 == Third-party Content
 
-polyglot
-* License: Universal Permissive License
+graalpy
+* License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graalpython

--- a/org.graalvm.python.python-resources/NOTICE
+++ b/org.graalvm.python.python-resources/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graalpython

--- a/org.graalvm.python.python-resources/osgi.bnd
+++ b/org.graalvm.python.python-resources/osgi.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
-Bundle-License: Unicode/ICU License
+Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
   *

--- a/org.graalvm.python.python-resources/osgi.bnd
+++ b/org.graalvm.python.python-resources/osgi.bnd
@@ -1,0 +1,13 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Unicode/ICU License
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="com.oracle.truffle.api.provider.InternalResourceProvider"  
+-includeresource: \
+  NOTICE

--- a/org.graalvm.python.python-resources/osgi.bnd
+++ b/org.graalvm.python.python-resources/osgi.bnd
@@ -2,8 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.python.python-resources/osgi.bnd
+++ b/org.graalvm.python.python-resources/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.python.python-resources/pom.xml
+++ b/org.graalvm.python.python-resources/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.python.python-resources</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Python :: Resources</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.python</origin.groupId>
+    <origin.artifactId>python-resources</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.regex.regex/NOTICE
+++ b/org.graalvm.regex.regex/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License, Version 1.0
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graal

--- a/org.graalvm.regex.regex/osgi.bnd
+++ b/org.graalvm.regex.regex/osgi.bnd
@@ -1,0 +1,13 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Universal Permissive License, Version 1.0
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="com.oracle.truffle.api.provider.TruffleLanguageProvider"  
+-includeresource: \
+  NOTICE

--- a/org.graalvm.regex.regex/osgi.bnd
+++ b/org.graalvm.regex.regex/osgi.bnd
@@ -2,8 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.regex.regex/osgi.bnd
+++ b/org.graalvm.regex.regex/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.regex.regex/pom.xml
+++ b/org.graalvm.regex.regex/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>org.graalvm.regex.regex</artifactId>
   <version>${graalvm.version}</version>
 
-  <name>GraalVM :: Regex :: Regex</name>
+  <name>GraalVM :: Regex :: TRegex</name>
 
   <properties>
     <origin.groupId>org.graalvm.regex</origin.groupId>

--- a/org.graalvm.regex.regex/pom.xml
+++ b/org.graalvm.regex.regex/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.regex.regex</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Regex :: Regex</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.regex</origin.groupId>
+    <origin.artifactId>regex</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.shadowed.json/NOTICE
+++ b/org.graalvm.shadowed.json/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graal

--- a/org.graalvm.shadowed.json/NOTICE
+++ b/org.graalvm.shadowed.json/NOTICE
@@ -15,6 +15,6 @@ https://github.com/openhab/openhab-osgiify
 == Third-party Content
 
 polyglot
-* License: Universal Permissive License
+* License: Universal Permissive License, Version 1.0
 * Project: http://www.graalvm.org
 * Source:  https://github.com/oracle/graal

--- a/org.graalvm.shadowed.json/osgi.bnd
+++ b/org.graalvm.shadowed.json/osgi.bnd
@@ -1,0 +1,12 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Unicode/ICU License
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE
+

--- a/org.graalvm.shadowed.json/osgi.bnd
+++ b/org.graalvm.shadowed.json/osgi.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
-Bundle-License: Unicode/ICU License
+Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
   *
@@ -9,4 +9,3 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.shadowed.json/osgi.bnd
+++ b/org.graalvm.shadowed.json/osgi.bnd
@@ -2,8 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.shadowed.json/osgi.bnd
+++ b/org.graalvm.shadowed.json/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.shadowed.json/pom.xml
+++ b/org.graalvm.shadowed.json/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.shadowed.json</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Truffle :: JSON</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.shadowed</origin.groupId>
+    <origin.artifactId>json</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.tools.profiler-tool/NOTICE
+++ b/org.graalvm.tools.profiler-tool/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License, Version 1.0
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graal

--- a/org.graalvm.tools.profiler-tool/osgi.bnd
+++ b/org.graalvm.tools.profiler-tool/osgi.bnd
@@ -9,4 +9,3 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.tools.profiler-tool/osgi.bnd
+++ b/org.graalvm.tools.profiler-tool/osgi.bnd
@@ -1,0 +1,12 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Universal Permissive License, Version 1.0
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE
+

--- a/org.graalvm.tools.profiler-tool/osgi.bnd
+++ b/org.graalvm.tools.profiler-tool/osgi.bnd
@@ -2,8 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.tools.profiler-tool/osgi.bnd
+++ b/org.graalvm.tools.profiler-tool/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.tools.profiler-tool/pom.xml
+++ b/org.graalvm.tools.profiler-tool/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.tools.profiler-tool</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Tools :: Profiler</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.tools</origin.groupId>
+    <origin.artifactId>profiler-tool</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.truffle.truffle-api/META-INF/services/org.graalvm.polyglot.impl.AbstractPolyglotImpl
+++ b/org.graalvm.truffle.truffle-api/META-INF/services/org.graalvm.polyglot.impl.AbstractPolyglotImpl
@@ -1,0 +1,1 @@
+com.oracle.truffle.polyglot.PolyglotImpl

--- a/org.graalvm.truffle.truffle-api/META-INF/services/org.graalvm.polyglot.impl.AbstractPolyglotImpl
+++ b/org.graalvm.truffle.truffle-api/META-INF/services/org.graalvm.polyglot.impl.AbstractPolyglotImpl
@@ -1,1 +1,0 @@
-com.oracle.truffle.polyglot.PolyglotImpl

--- a/org.graalvm.truffle.truffle-api/NOTICE
+++ b/org.graalvm.truffle.truffle-api/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License, Version 1.0
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graal

--- a/org.graalvm.truffle.truffle-api/osgi.bnd
+++ b/org.graalvm.truffle.truffle-api/osgi.bnd
@@ -1,0 +1,28 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Universal Permissive License, Version 1.0
+Bundle-Version: ${project.version}
+Import-Package: \
+  jdk.internal.access;resolution:="optional", \
+  jdk.internal.module;resolution:="optional", \
+  jdk.internal.reflect;resolution:="optional", \
+  jdk.jfr;resolution:="optional", \
+  org.graalvm.*;resolution:="optional", \
+  com.oracle.truffle.*;resolution:="optional", \
+  sun.reflect;resolution:="optional", \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+Require-Capability: \
+  osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)", \
+  osgi.extender;filter:="(osgi.extender=osgi.serviceloader.processor)", \
+  osgi.serviceloader; \
+    filter:="(osgi.serviceloader=com.oracle.truffle.api.provider.TruffleLanguageProvider)"; \
+    cardinality:=multiple, \
+  osgi.serviceloader; \
+    filter:="(osgi.serviceloader=com.oracle.truffle.api.provider.InternalResourceProvider)"; \
+    cardinality:=multiple
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="org.graalvm.polyglot.impl.AbstractPolyglotImpl"
+-includeresource: \
+  NOTICE

--- a/org.graalvm.truffle.truffle-api/osgi.bnd
+++ b/org.graalvm.truffle.truffle-api/osgi.bnd
@@ -6,9 +6,6 @@ Import-Package: \
   jdk.internal.access;resolution:="optional", \
   jdk.internal.module;resolution:="optional", \
   jdk.internal.reflect;resolution:="optional", \
-  jdk.jfr;resolution:="optional", \
-  org.graalvm.*;resolution:="optional", \
-  com.oracle.truffle.*;resolution:="optional", \
   sun.reflect;resolution:="optional", \
   *
 Export-Package: \
@@ -22,7 +19,8 @@ Require-Capability: \
     cardinality:=multiple, \
   osgi.serviceloader; \
     filter:="(osgi.serviceloader=com.oracle.truffle.api.provider.InternalResourceProvider)"; \
-    cardinality:=multiple
+    cardinality:=multiple; \
+    resolution:="optional"
 Provide-Capability: osgi.serviceloader;osgi.serviceloader="org.graalvm.polyglot.impl.AbstractPolyglotImpl"
 -includeresource: \
   NOTICE

--- a/org.graalvm.truffle.truffle-api/pom.xml
+++ b/org.graalvm.truffle.truffle-api/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.truffle.truffle-api</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Truffle :: API</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.truffle</origin.groupId>
+    <origin.artifactId>truffle-api</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.truffle.truffle-compiler/osgi.bnd
+++ b/org.graalvm.truffle.truffle-compiler/osgi.bnd
@@ -10,3 +10,4 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
+

--- a/org.graalvm.truffle.truffle-compiler/osgi.bnd
+++ b/org.graalvm.truffle.truffle-compiler/osgi.bnd
@@ -10,4 +10,3 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.truffle.truffle-nfi/NOTICE
+++ b/org.graalvm.truffle.truffle-nfi/NOTICE
@@ -1,0 +1,20 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-osgiify
+
+== Third-party Content
+
+polyglot
+* License: Universal Permissive License, Version 1.0
+* Project: http://www.graalvm.org
+* Source:  https://github.com/oracle/graal

--- a/org.graalvm.truffle.truffle-nfi/osgi.bnd
+++ b/org.graalvm.truffle.truffle-nfi/osgi.bnd
@@ -9,4 +9,3 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.truffle.truffle-nfi/osgi.bnd
+++ b/org.graalvm.truffle.truffle-nfi/osgi.bnd
@@ -1,0 +1,12 @@
+Bundle-Description: OSGi-ified version of ${project.name}
+Bundle-Name: ${project.name}
+Bundle-License: Universal Permissive License, Version 1.0
+Bundle-Version: ${project.version}
+Import-Package: \
+  *
+Export-Package: \
+  !NOTICE, \
+  *;version=${project.version}
+-includeresource: \
+  NOTICE
+

--- a/org.graalvm.truffle.truffle-nfi/osgi.bnd
+++ b/org.graalvm.truffle.truffle-nfi/osgi.bnd
@@ -2,8 +2,6 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
-Import-Package: \
-  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.truffle.truffle-nfi/osgi.bnd
+++ b/org.graalvm.truffle.truffle-nfi/osgi.bnd
@@ -2,6 +2,8 @@ Bundle-Description: OSGi-ified version of ${project.name}
 Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
+Import-Package: \
+  *
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}

--- a/org.graalvm.truffle.truffle-nfi/pom.xml
+++ b/org.graalvm.truffle.truffle-nfi/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.osgiify</groupId>
+    <artifactId>org.openhab.reactor.osgiify</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>org.graalvm.truffle.truffle-nfi</artifactId>
+  <version>${graalvm.version}</version>
+
+  <name>GraalVM :: Truffle :: NFI</name>
+
+  <properties>
+    <origin.groupId>org.graalvm.truffle</origin.groupId>
+    <origin.artifactId>truffle-nfi</origin.artifactId>
+  </properties>
+
+</project>

--- a/org.graalvm.truffle.truffle-runtime/osgi.bnd
+++ b/org.graalvm.truffle.truffle-runtime/osgi.bnd
@@ -15,4 +15,3 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
-

--- a/org.graalvm.truffle.truffle-runtime/osgi.bnd
+++ b/org.graalvm.truffle.truffle-runtime/osgi.bnd
@@ -11,3 +11,4 @@ Export-Package: \
   *;version=${project.version}
 -includeresource: \
   NOTICE
+

--- a/org.graalvm.truffle.truffle-runtime/osgi.bnd
+++ b/org.graalvm.truffle.truffle-runtime/osgi.bnd
@@ -3,12 +3,8 @@ Bundle-Name: ${project.name}
 Bundle-License: Universal Permissive License, Version 1.0
 Bundle-Version: ${project.version}
 Import-Package: \
-  jdk.internal.access;resolution:="optional", \
-  jdk.internal.module;resolution:="optional", \
   jdk.jfr;resolution:="optional", \
   jdk.vm.ci.*;resolution:="optional", \
-  org.graalvm.*;resolution:="optional", \
-  com.oracle.truffle.*;resolution:="optional", \
   *
 Export-Package: \
   !NOTICE, \

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <module>net.vrallev.ecc.ecc-25519-java</module>
     <module>org.cups4j.cups4j</module>
     <module>org.graalvm.js.js-language</module>
+    <module>org.graalvm.js.js-scriptengine</module>
     <module>org.graalvm.llvm.llvm-api</module>
     <module>org.graalvm.polyglot.polyglot</module>
     <module>org.graalvm.python.python-embedding</module>

--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,24 @@
     <module>javazoom.jlayer</module>
     <module>net.vrallev.ecc.ecc-25519-java</module>
     <module>org.cups4j.cups4j</module>
+    <module>org.graalvm.js.js-language</module>
+    <module>org.graalvm.llvm.llvm-api</module>
+    <module>org.graalvm.polyglot.polyglot</module>
+    <module>org.graalvm.python.python-embedding</module>
+    <module>org.graalvm.python.python-language</module>
+    <module>org.graalvm.python.python-resources</module>
+    <module>org.graalvm.regex.regex</module>
     <module>org.graalvm.sdk.collections</module>
     <module>org.graalvm.sdk.jniutils</module>
     <module>org.graalvm.sdk.nativeimage</module>
     <module>org.graalvm.sdk.word</module>
     <module>org.graalvm.shadowed.icu4j</module>
+    <module>org.graalvm.shadowed.json</module>
     <module>org.graalvm.shadowed.xz</module>
+    <module>org.graalvm.tools.profiler-tool</module>
+    <module>org.graalvm.truffle.truffle-api</module>
     <module>org.graalvm.truffle.truffle-compiler</module>
+    <module>org.graalvm.truffle.truffle-nfi</module>
     <module>org.graalvm.truffle.truffle-runtime</module>
     <module>org.json.json</module>
     <module>org.pcap4j.pcap4j-core</module>


### PR DESCRIPTION
Graal uses ServiceLoader internally (and between its JARs), so use the OSGi Service Loader Mediator to export SPI exported clases to OSGi as well, and to hook ("weave" is the internal term) ServiceLoader.load to be able to find these classes from other OSGi bundles instead of from the system class loader that Graal assumes

Note that ServiceLoader isn't fully OSGi aware, so it won't wait until bundles that provides services it needs are loaded, so the startlevel of the bundles will need to be set by any karaf features that reference some of these bundles before the bundle that expects to load them via ServiceLoader is loaded:
 * truffle-api must start before polyglot
 * any languages or their resources must start before truffle-api