### PR TITLE
OSGi-ify fix Graal nfi osgi.bnd

### DIFF
--- a/org.graalvm.truffle.truffle-nfi/osgi.bnd
+++ b/org.graalvm.truffle.truffle-nfi/osgi.bnd
@@ -7,5 +7,7 @@ Import-Package: \
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
+Provide-Capability: osgi.serviceloader;osgi.serviceloader="com.oracle.truffle.api.provider.TruffleLanguageProvider"
 -includeresource: \
   NOTICE


### PR DESCRIPTION
here comes a follow up pull request of https://github.com/openhab/openhab-osgiify/pull/66

not only libffi is a TruffleLanguageProvider. nfi itself is a TruffleLanguageProvider too.

nfi language provider, provides the language "nfi"

libffi language provider, provides the nfi backend "native"

@ccutrer @florian-h05 can you please approve
