### PR TITLE
Upgrade Dagger to 2.42

### DIFF
--- a/com.google.dagger/pom.xml
+++ b/com.google.dagger/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>com.google.dagger</artifactId>
-  <version>2.27</version>
+  <version>2.42</version>
 
   <name>Dagger</name>
 


### PR DESCRIPTION
Updates transitive dependency of hivemq-mqtt-client.