### PR TITLE
Fixes removal of graalvm from aws-crt package

### DIFF
--- a/software.amazon.awssdk.crt.aws-crt/osgi.bnd
+++ b/software.amazon.awssdk.crt.aws-crt/osgi.bnd
@@ -3,10 +3,12 @@ Bundle-Name: ${project.name}
 Bundle-License: Apache 2.0 License
 Bundle-Version: ${project.version}
 Import-Package: \
+  !org.graalvm.nativeimage.hosted, \
   *
+
 Export-Package: \
   !NOTICE, \
   *;version=${project.version}
+
 -includeresource: \
   NOTICE
-

--- a/software.amazon.awssdk.crt.aws-crt/osgi.bnd
+++ b/software.amazon.awssdk.crt.aws-crt/osgi.bnd
@@ -3,7 +3,7 @@ Bundle-Name: ${project.name}
 Bundle-License: Apache 2.0 License
 Bundle-Version: ${project.version}
 Import-Package: \
-  !org.graalvm.nativeimage.hosted, \
+  org.graalvm.nativeimage.hosted*;resolution:=optional, \
   *
 
 Export-Package: \


### PR DESCRIPTION
This was the main reason to add the package in the first place.