### PR TITLE
[com.hubspot.jinjava.jinjava] Add algebra dependency and resolve runtime import blocks

### DIFF
--- a/com.hubspot.jinjava.jinjava/osgi.bnd
+++ b/com.hubspot.jinjava.jinjava/osgi.bnd
@@ -5,6 +5,9 @@ Bundle-Version: ${project.version}
 Import-Package: \
   javax.annotation.*;resolution:="optional", \
   com.googlecode.ipv6.*;resolution:="optional", \
+  android.os;resolution:=optional, \
+  com.google.appengine.api.*;resolution:="optional", \
+  com.google.apphosting.api.*;resolution:="optional", \
   *
 Export-Package: \
   !NOTICE, \

--- a/com.hubspot.jinjava.jinjava/pom.xml
+++ b/com.hubspot.jinjava.jinjava/pom.xml
@@ -20,4 +20,27 @@
     <origin.version>2.8.3</origin.version>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.hubspot</groupId>
+      <artifactId>algebra</artifactId>
+      <version>1.7.2</version>
+      <exclusions>
+        <!-- Don't include Jackson dependencies in the bundle jar; we'll use openHAB's versions of Jackson bundle -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
 </project>


### PR DESCRIPTION
- Explicitly add `com.hubspot:algebra` dependency with transitive Jackson exclusions to use openHAB platform core versions.
- Patch `osgi.bnd` to mark `android.os` and `com.google.appengine/apphosting` packages as optional runtime imports.

